### PR TITLE
fixed tweet_id parseing bug

### DIFF
--- a/src/js/tweet-parser.js
+++ b/src/js/tweet-parser.js
@@ -46,7 +46,7 @@ const getTweetInfo = (tweet) => {
 
   const user = tweet.querySelector(usernameSelector) ? tweet.querySelector(usernameSelector).textContent : null;
   const text = tweet.querySelector(textSelector) ? tweet.querySelector(textSelector).textContent : null;
-  const tweetid = tweet.querySelector(tweetIdSelector) ? tweet.querySelector(tweetIdSelector).href.match(/\d+\b/g)[0] : null;
+  const tweetid = tweet.querySelector(tweetIdSelector) ? tweet.querySelector(tweetIdSelector).href.match(/\d+$/g)[0] : null;
 
   const mock = {
     username: user,


### PR DESCRIPTION
The old regexp selected the wrong part of the string under some conditions